### PR TITLE
Use system spaces to resolve space and index names

### DIFF
--- a/const.lua
+++ b/const.lua
@@ -55,6 +55,10 @@ SPACE_USER    = 304
 SPACE_PRIV    = 312
 SPACE_CLUSTER = 320
 
+-- default views
+VIEW_SPACE    = 281
+VIEW_INDEX    = 289
+
 -- index info
 INDEX_SPACE_PRIMARY = 0
 INDEX_SPACE_NAME    = 2

--- a/tarantool.lua
+++ b/tarantool.lua
@@ -326,7 +326,7 @@ do
       else
         return nil, 'Invalid space identificator: ' .. space
       end
-      local data, err = self:select(C.SPACE_SPACE, C.INDEX_SPACE_NAME, space)
+      local data, err = self:select(C.VIEW_SPACE, C.INDEX_SPACE_NAME, space)
       if not data or not data[1] or not data[1][1] or err then
         return nil, (err or 'Can\'t find space with identifier: ' .. space)
       end
@@ -351,7 +351,7 @@ do
         return nil, err
       end
       local data
-      data, err = self:select(C.SPACE_INDEX, C.INDEX_INDEX_NAME, {
+      data, err = self:select(C.VIEW_INDEX, C.INDEX_INDEX_NAME, {
         spaceno,
         index
       })


### PR DESCRIPTION
Without this change, it's not possible to resolve space and index names to numeric id's.